### PR TITLE
bump node.js version to fix installation and upgrade problem

### DIFF
--- a/install
+++ b/install
@@ -61,7 +61,7 @@ fi
 
 debug="lamassu-debug.log"
 prefix="/usr/local"
-node="http://nodejs.org/dist/v0.10.26/node-v0.10.26-linux-x64.tar.gz"
+node="http://nodejs.org/dist/v0.10.32/node-v0.10.32-linux-x64.tar.gz"
 
 # First detect our package manager. Fail early if we don't support it.
 update=""


### PR DESCRIPTION
Looks like some of the lamassu packages can't really work with
node.js v0.10.26, bump the version number that seems to work. The
minimum is v0.10.31 to some package, to be safe go to the latest
v0.10.32.
