### PR TITLE
use apt-get for postgresql

### DIFF
--- a/install
+++ b/install
@@ -73,10 +73,8 @@ if exists apt-get; then
   update="apt-get update -y"
   upgrade="apt-get upgrade -y"
   install="
-    echo \"deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -c | awk '{print $2}')-pgdg main\" > /etc/apt/sources.list.d/pgdg.list &&
-    curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - &&
     apt-get update -y &&
-    apt-get install -y postgresql-9.4 libpq-dev git build-essential
+    apt-get install -y  postgresql postgresql-contrib libpq-dev git build-essential
   "
 fi
 


### PR DESCRIPTION
Use apt-get for PostgreSQL so that it doesn't keep breaking the install.
