### PR TITLE
fix lamassu-backup-pg installation when crontab is missing

### DIFF
--- a/install
+++ b/install
@@ -188,7 +188,7 @@ BIN=$(npm -g bin)
 BACKUP_CMD=$BIN/lamassu-backup-pg
 mkdir -p $BACKUP_DIR
 BACKUP_CRON="@daily $BACKUP_CMD > /dev/null"
-(crontab -l 2>/dev/null; echo "$BACKUP_CRON") | crontab - >> $LOG_FILE 2>&1
+(crontab -l 2>/dev/null || echo -n ""; echo "$BACKUP_CRON") | crontab - >> $LOG_FILE 2>&1
 $BACKUP_CMD >> $LOG_FILE 2>&1
 
 decho "Setting up firewall..."


### PR DESCRIPTION
Sorry @joshmh,
I missed to apply the same fix on stable branch.