### PR TITLE
lamassu-install to /opt/lamassu-server

### DIFF
--- a/install
+++ b/install
@@ -165,7 +165,7 @@ openssl x509 \
 rm /tmp/Lamassu_OP.csr.pem
 
 decho "Copying Lamassu certificate authority..."
-LAMASSU_CA_FILE=${INSTALL_DIR}/Lamassu_CA.pem
+LAMASSU_CA_FILE=${INSTALL_DIR}/node_modules/lamassu-server/Lamassu_CA.pem
 cp -v $LAMASSU_CA_FILE $LAMASSU_CA_PATH >> $LOG_FILE 2>&1
 
 mkdir -p $OFAC_DATA_DIR >> $LOG_FILE 2>&1

--- a/install
+++ b/install
@@ -7,17 +7,18 @@ INSTALL_DIR=/opt/lamassu-server
 CERT_DIR=/etc/ssl/certs
 KEY_DIR=/etc/ssl/private
 CONFIG_DIR=/etc/lamassu
+BACKUP_DIR=/var/backups/postgresql
+BLOCKCHAIN_DIR=/mnt/blockchains
+OFAC_DATA_DIR=/var/lamassu/ofac
+SEEDS_DIR=$HOME/seeds
+
 MIGRATE_STATE_PATH=$CONFIG_DIR/.migrate
 LAMASSU_CA_PATH=$CERT_DIR/Lamassu_CA.pem
 CA_KEY_PATH=$KEY_DIR/Lamassu_OP_Root_CA.key
 CA_PATH=$CERT_DIR/Lamassu_OP_Root_CA.pem
 SERVER_KEY_PATH=$KEY_DIR/Lamassu_OP.key
 SERVER_CERT_PATH=$CERT_DIR/Lamassu_OP.pem
-SEEDS_DIR=$HOME/seeds
 SEED_FILE=$SEEDS_DIR/seed.txt
-BACKUP_DIR=/var/backups/postgresql
-BLOCKCHAIN_DIR=/mnt/blockchains
-OFAC_DATA_DIR=/var/lamassu/ofac
 
 # Look into http://unix.stackexchange.com/questions/140734/configure-localtime-dpkg-reconfigure-tzdata
 

--- a/install
+++ b/install
@@ -3,6 +3,7 @@ set -e
 
 export LOG_FILE=/tmp/install.log
 
+INSTALL_DIR=/opt/lamassu-server
 CERT_DIR=/etc/ssl/certs
 KEY_DIR=/etc/ssl/private
 CONFIG_DIR=/etc/lamassu
@@ -97,11 +98,18 @@ echo $SEED > $SEED_FILE
 
 decho "Installing latest npm package manager for node..."
 retry 3 npm -g --unsafe-perm install npm@5  >> $LOG_FILE 2>&1
-NODE_MODULES=$(npm -g root)
-NPM_BIN=$(npm -g bin)
 
 decho "Installing lamassu-server..."
-retry 3 npm -g --unsafe-perm install lamassu/lamassu-server#master >> $LOG_FILE 2>&1
+mkdir -vp ${INSTALL_DIR} >> $LOG_FILE 2>&1
+cd ${INSTALL_DIR} >> $LOG_FILE 2>&1
+retry 3 npm --unsafe-perm install --production lamassu/lamassu-server#master >> $LOG_FILE 2>&1
+shopt -s dotglob >> $LOG_FILE 2>&1
+mv -fv ${INSTALL_DIR}/node_modules/lamassu-server/* ${INSTALL_DIR}/ >> $LOG_FILE 2>&1
+rm -Rfv ${INSTALL_DIR}/node_modules/lamassu-server/ >> $LOG_FILE 2>&1
+
+decho "Adding ${INSTALL_DIR}/bin to PATH"
+export PATH=${PATH}:${INSTALL_DIR}/bin
+perl -i -pe 's/PATH=.*/PATH=$ENV{PATH}/g' /etc/environment >> ${LOG_FILE} 2>&1
 
 decho "Creating postgres user..."
 POSTGRES_PW=$(hkdf postgres-pw $SEED)
@@ -158,10 +166,10 @@ openssl x509 \
 rm /tmp/Lamassu_OP.csr.pem
 
 decho "Copying Lamassu certificate authority..."
-LAMASSU_CA_FILE=$NODE_MODULES/lamassu-server/Lamassu_CA.pem
-cp $LAMASSU_CA_FILE $LAMASSU_CA_PATH
+LAMASSU_CA_FILE=${INSTALL_DIR}/Lamassu_CA.pem
+cp -v $LAMASSU_CA_FILE $LAMASSU_CA_PATH >> $LOG_FILE 2>&1
 
-mkdir -p $OFAC_DATA_DIR
+mkdir -p $OFAC_DATA_DIR >> $LOG_FILE 2>&1
 
 cat <<EOF > $CONFIG_DIR/lamassu.json
 {
@@ -193,8 +201,7 @@ ADMIN_REGISTRATION_URL=`lamassu-register admin 2>> $LOG_FILE`
 lamassu-apply-defaults >> $LOG_FILE 2>&1
 
 decho "Setting up backups..."
-BIN=$(npm -g bin)
-BACKUP_CMD=$BIN/lamassu-backup-pg
+BACKUP_CMD=${INSTALL_DIR}/bin/lamassu-backup-pg
 mkdir -p $BACKUP_DIR
 BACKUP_CRON="@daily $BACKUP_CMD > /dev/null"
 (crontab -l 2>/dev/null || echo -n ""; echo "$BACKUP_CRON") | crontab - >> $LOG_FILE 2>&1
@@ -210,7 +217,7 @@ ufw -f enable >> $LOG_FILE 2>&1
 decho "Setting up supervisor..."
 cat <<EOF > /etc/supervisor/conf.d/lamassu-server.conf
 [program:lamassu-server]
-command=${NPM_BIN}/lamassu-server
+command=${INSTALL_DIR}/bin/lamassu-server
 autostart=true
 autorestart=true
 stderr_logfile=/var/log/supervisor/lamassu-server.err.log
@@ -220,7 +227,7 @@ EOF
 
 cat <<EOF > /etc/supervisor/conf.d/lamassu-admin-server.conf
 [program:lamassu-admin-server]
-command=${NPM_BIN}/lamassu-admin-server
+command=${INSTALL_DIR}/bin/lamassu-admin-server
 autostart=true
 autorestart=true
 stderr_logfile=/var/log/supervisor/lamassu-admin-server.err.log

--- a/install
+++ b/install
@@ -90,7 +90,7 @@ curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash - >> $LOG_FILE 2>&1
 apt update >> $LOG_FILE 2>&1
 
 decho "Installing necessary packages..."
-apt install nodejs python-minimal build-essential supervisor postgresql libpq-dev -y -q >> $LOG_FILE 2>&1
+apt install nodejs python-minimal build-essential supervisor postgresql libpq-dev git -y -q >> $LOG_FILE 2>&1
 
 decho "Generating seed..."
 mkdir -p $SEEDS_DIR >> $LOG_FILE 2>&1
@@ -101,10 +101,9 @@ decho "Installing latest npm package manager for node..."
 retry 3 npm -g --unsafe-perm install npm@5  >> $LOG_FILE 2>&1
 
 decho "Installing lamassu-server..."
-mkdir -vp ${INSTALL_DIR} >> $LOG_FILE 2>&1
+git clone https://github.com/lamassu/lamassu-server.git --branch master ${INSTALL_DIR} >> $LOG_FILE 2>&1
 cd ${INSTALL_DIR} >> $LOG_FILE 2>&1
-retry 3 npm --unsafe-perm install --production lamassu/lamassu-server#master >> $LOG_FILE 2>&1
-ln -s ${INSTALL_DIR}/node_modules/lamassu-server/bin ${INSTALL_DIR}/bin >> $LOG_FILE 2>&1
+retry 3 npm --unsafe-perm install --production >> $LOG_FILE 2>&1
 
 decho "Adding ${INSTALL_DIR}/bin to PATH"
 export PATH=${PATH}:${INSTALL_DIR}/bin
@@ -165,7 +164,7 @@ openssl x509 \
 rm /tmp/Lamassu_OP.csr.pem
 
 decho "Copying Lamassu certificate authority..."
-LAMASSU_CA_FILE=${INSTALL_DIR}/node_modules/lamassu-server/Lamassu_CA.pem
+LAMASSU_CA_FILE=${INSTALL_DIR}/Lamassu_CA.pem
 cp -v $LAMASSU_CA_FILE $LAMASSU_CA_PATH >> $LOG_FILE 2>&1
 
 mkdir -p $OFAC_DATA_DIR >> $LOG_FILE 2>&1

--- a/install
+++ b/install
@@ -104,9 +104,7 @@ decho "Installing lamassu-server..."
 mkdir -vp ${INSTALL_DIR} >> $LOG_FILE 2>&1
 cd ${INSTALL_DIR} >> $LOG_FILE 2>&1
 retry 3 npm --unsafe-perm install --production lamassu/lamassu-server#master >> $LOG_FILE 2>&1
-shopt -s dotglob >> $LOG_FILE 2>&1
-mv -fv ${INSTALL_DIR}/node_modules/lamassu-server/* ${INSTALL_DIR}/ >> $LOG_FILE 2>&1
-rm -Rfv ${INSTALL_DIR}/node_modules/lamassu-server/ >> $LOG_FILE 2>&1
+ln -s ${INSTALL_DIR}/node_modules/lamassu-server/bin ${INSTALL_DIR}/bin >> $LOG_FILE 2>&1
 
 decho "Adding ${INSTALL_DIR}/bin to PATH"
 export PATH=${PATH}:${INSTALL_DIR}/bin


### PR DESCRIPTION
_/opt/lamassu-server/bin_ is being added to default PATH:

```
root@test-install-fabio:~# cat /etc/environment 
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/opt/lamassu-server/bin
```

This is the new installation path:

```
root@test-install-fabio:/# cd /opt/lamassu-server/
root@test-install-fabio:/opt/lamassu-server# ls -l
total 228
lrwxrwxrwx   1 root root     51 Nov 21 03:53 bin -> /opt/lamassu-server/node_modules/lamassu-server/bin
drwxr-xr-x 562 root root  20480 Nov 21 03:53 node_modules
-rw-r--r--   1 root root 212844 Nov 21 03:53 package-lock.json
```

These are supervisor changes:

```
root@test-install-fabio:/etc/supervisor/conf.d# pwd
/etc/supervisor/conf.d
root@test-install-fabio:/etc/supervisor/conf.d# cat *
[program:lamassu-admin-server]
command=/opt/lamassu-server/bin/lamassu-admin-server
autostart=true
autorestart=true
stderr_logfile=/var/log/supervisor/lamassu-admin-server.err.log
stdout_logfile=/var/log/supervisor/lamassu-admin-server.out.log
environment=HOME="/root"
[program:lamassu-server]
command=/opt/lamassu-server/bin/lamassu-server
autostart=true
autorestart=true
stderr_logfile=/var/log/supervisor/lamassu-server.err.log
stdout_logfile=/var/log/supervisor/lamassu-server.out.log
environment=HOME="/root"

root@test-install-fabio:/etc/supervisor/conf.d# supervisorctl status
lamassu-admin-server             RUNNING   pid 14474, uptime 0:03:58
lamassu-server                   RUNNING   pid 14473, uptime 0:03:58
```