### PR TITLE
Add ofacSources to lamassu.json

### DIFF
--- a/install
+++ b/install
@@ -183,7 +183,17 @@ cat <<EOF > $CONFIG_DIR/lamassu.json
   },
   "coinAtmRadar": {
     "url": "https://coinatmradar.info/api/lamassu/"
-  }
+  },
+  "ofacSources": [
+    {
+      "name": "sdn_advanced",
+      "url": "https://www.treasury.gov/ofac/downloads/sanctions/1.0/sdn_advanced.xml"
+    },
+    {
+      "name": "cons_advanced",
+      "url": "https://www.treasury.gov/ofac/downloads/sanctions/1.0/cons_advanced.xml"
+    }
+  ]
 }
 EOF
 


### PR DESCRIPTION
We're adding this upon running `lamassu-update` through `lamassu-ofac-update-sources` when going from v7.1 to v7.2, but this is not included by default in the v7.2 installer.