### PR TITLE
fix: update packages to support latest zcashd

### DIFF
--- a/install
+++ b/install
@@ -106,14 +106,18 @@ apt update >> $LOG_FILE 2>&1
 
 decho "Installing necessary packages..."
 apt install nodejs python-minimal build-essential supervisor postgresql libpq-dev -y -q >> $LOG_FILE 2>&1
+add-apt-repository -y ppa:ubuntu-toolchain-r/test >> $LOG_FILE 2>&1
+apt update >> $LOG_FILE 2>&1
+apt install -y gcc-4.9 >> $LOG_FILE 2>&1
+apt install -y --only-upgrade libstdc++6 >> $LOG_FILE 2>&1
 
 decho "Installing latest npm package manager for node..."
 retry 3 npm -g --unsafe-perm install npm@5  >> $LOG_FILE 2>&1
 NODE_MODULES=$(npm -g root)
 NPM_BIN=$(npm -g bin)
 
-decho "Installing lamassu-server (Defiant Dingirma v7.4.9)..."
-retry 3 npm -g --unsafe-perm install lamassu/lamassu-server#v7.4.9 >> $LOG_FILE 2>&1
+decho "Installing lamassu-server (Defiant Dingirma v7.4.10)..."
+retry 3 npm -g --unsafe-perm install lamassu/lamassu-server#v7.4.10 >> $LOG_FILE 2>&1
 
 decho "Generating mnemonic..."
 mkdir -p $MNEMONIC_DIR >> $LOG_FILE 2>&1

--- a/upgrade
+++ b/upgrade
@@ -54,12 +54,18 @@ n 8 >> ${LOG_FILE} 2>&1
 decho "version installed $(node -v)"
 export NPM_BIN=$(npm -g bin)
 
-decho "updating to lamassu-server (Defiant Dingirma v7.4.9)"
-npm -g install lamassu/lamassu-server#v7.4.9 --unsafe-perm >> ${LOG_FILE} 2>&1
+decho "updating to lamassu-server (Defiant Dingirma v7.4.10)"
+npm -g install lamassu/lamassu-server#v7.4.10 --unsafe-perm >> ${LOG_FILE} 2>&1
 
 decho "rebuilding npm deps"
 cd $(npm root -g)/lamassu-server/ >> ${LOG_FILE} 2>&1
 npm rebuild >> ${LOG_FILE} 2>&1
+
+decho "updating system dependencies"
+add-apt-repository -y ppa:ubuntu-toolchain-r/test >> $LOG_FILE 2>&1
+apt update >> $LOG_FILE 2>&1
+apt install -y gcc-4.9 >> $LOG_FILE 2>&1
+apt install -y --only-upgrade libstdc++6 >> $LOG_FILE 2>&1
 
 {
 decho "running migration"


### PR DESCRIPTION
Required for zcashd v4.0.0, as support for Jessie was dropped. Now building for Stretch.